### PR TITLE
Fix missing space between input and button

### DIFF
--- a/src/dokumentvwsys/app/views/devise/sessions/new.html.erb
+++ b/src/dokumentvwsys/app/views/devise/sessions/new.html.erb
@@ -4,15 +4,15 @@
       <form class="form-signin">
         <div class="form-label-group">
           <div class="center_div"><img src="/hi.png" id="icon" alt="User Icon"/></div>
-          <%= f.label :username, t('label.username') %><br />
+          <%= f.label :username, t('label.username') %>
           <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "form-control" %>
 
-          <%= f.label :password, t('label.password') %><br />
+          <%= f.label :password, t('label.password') %>
           <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
         </div>
 
         <div class="actions">
-          <%= f.submit t('button.login'), class: "btn btn-primary btn-lg btn-block" %>
+          <%= f.submit t('button.login'), class: "btn btn-primary btn-lg btn-block mt-3" %>
         </div>
         <div><%= render "devise/shared/links" %></div>
       </form>


### PR DESCRIPTION
--- Why is this change necessary?
It does not look good witout the space

--- How does it address the issue?
Insert space after password field