### PR TITLE
Administration: Disable delete for own user

### DIFF
--- a/src/dokumentvwsys/app/controllers/administration_controller.rb
+++ b/src/dokumentvwsys/app/controllers/administration_controller.rb
@@ -23,7 +23,7 @@ class AdministrationController < ApplicationController
 
   def destroy
     if params[:id].to_i == current_user.id
-      redirect_to administration_index_path,
+      return redirect_to administration_index_path,
                   flash: { error: 'Cannot delete yourself' }
     end
 

--- a/src/dokumentvwsys/app/controllers/administration_controller.rb
+++ b/src/dokumentvwsys/app/controllers/administration_controller.rb
@@ -24,7 +24,7 @@ class AdministrationController < ApplicationController
   def destroy
     if params[:id].to_i == current_user.id
       return redirect_to administration_index_path,
-                  flash: { error: 'Cannot delete yourself' }
+                         flash: { error: 'Cannot delete yourself' }
     end
 
     User.find(params[:id]).destroy

--- a/src/dokumentvwsys/app/views/administration/index.html.erb
+++ b/src/dokumentvwsys/app/views/administration/index.html.erb
@@ -18,7 +18,9 @@
         Geburtsdatum: <%= user.birth.strftime("%d.%m.%Y") %> <br>
       </p>
       <%= link_to 'Edit', edit_administration_path(user.id), class: 'card-link' %>
-      <%= link_to 'Delete', administration_path(user.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'card-link' %>
+      <% if user != current_user %>
+        <%= link_to 'Delete', administration_path(user.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'card-link' %>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
--- Why is this change necessary?
A user should not be able to delete himself

--- How does it address the issue?
1. There was a missing return. The result was that the user was deleted
   and an error message was thrown
2. Remove the delete button for the own user.

Closing #53 