### PR TITLE
Preferences: Fix width in preferences editor

### DIFF
--- a/src/dokumentvwsys/app/views/preferences/_form.html.erb
+++ b/src/dokumentvwsys/app/views/preferences/_form.html.erb
@@ -1,14 +1,16 @@
-<%= form_for preference, html: { class: 'form-inline' } do |f| %>
+<%= form_for preference, html: { class: 'form-inline row' } do |f| %>
   <%= f.text_field :key, value: preference.key, hidden: true %>
-  <div class="form-group mx-sm-3 mb-2">
-    <%= f.label :description, "Description", class: 'sr-only' %>
+
+  <div class="col-5 input-group">
     <%= f.text_field :description, value: t(preference.description, default: preference.description), class: 'form-control', readonly: true %>
   </div>
 
-  <div class="form-group mx-sm-3 mb-2">
+  <div class="col-5 input-group">
     <%= f.label :value, 'Value', class: 'sr-only' %>
     <%= f.text_field :value, value: preference.value, class: "form-control" %>
   </div>
 
-  <%= f.submit 'Save', class: 'btn btn-primary mb-2' %>
+  <div class="col">
+    <%= f.submit 'Save', class: 'btn btn-primary' %>
+  </div>
 <% end %>

--- a/src/dokumentvwsys/app/views/preferences/index.html.erb
+++ b/src/dokumentvwsys/app/views/preferences/index.html.erb
@@ -2,8 +2,8 @@
 
 <% @preferences.each do |group, settings| %>
   <h2><%= t("preferences.group.#{group}") %></h2>
-  <% settings.each do |setting| %>
-    <%= render 'form', preference: setting %>
-  <% end %>
-  <hr/>
+    <% settings.each do |setting| %>
+      <%= render 'form', preference: setting %>
+    <% end %>
+    <hr/>
 <% end %>

--- a/src/dokumentvwsys/app/views/preferences/index.html.erb
+++ b/src/dokumentvwsys/app/views/preferences/index.html.erb
@@ -2,8 +2,8 @@
 
 <% @preferences.each do |group, settings| %>
   <h2><%= t("preferences.group.#{group}") %></h2>
-    <% settings.each do |setting| %>
-      <%= render 'form', preference: setting %>
-    <% end %>
-    <hr/>
+  <% settings.each do |setting| %>
+    <%= render 'form', preference: setting %>
+  <% end %>
+  <hr/>
 <% end %>


### PR DESCRIPTION
--- Why is this change necessary?
The fields on the Preferences site were not wide enough. This was caused
by a wrong bootstrap class.

--- How does it address the issue?
Add the correct bootstrap classes.

Closing #59