### PR TITLE
Administration Panel: Change autofocus in generate user form

### DIFF
--- a/src/dokumentvwsys/app/views/administration/_form.html.erb
+++ b/src/dokumentvwsys/app/views/administration/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@user, url: user_registration_path) do |f| %>
   <div class="form-group">
     <%= f.label :first_name, t('label.first_name') %>
-    <%= f.text_field :first_name, class: "form-control" %>
+    <%= f.text_field :first_name, autofocus: true, class: "form-control" %>
   </div>
 
   <div class="form-group">
@@ -13,7 +13,7 @@
     <%= f.label :username, t('label.username') %>
     <div class="row">
       <div class="col-9">
-        <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "form-control" %>
+        <%= f.text_field :username, autocomplete: "username", class: "form-control" %>
       </div>
       <div class="col-3">
         <button type="button" class="btn btn-outline-dark" onclick="generateUsername()"><%= t('button.generate_username') %></button>


### PR DESCRIPTION
--- Why is this change necessary?
The autofocus was on the username field but should be on the first
field.