### PR TITLE
Preferences: Fix preferences views

### DIFF
--- a/src/dokumentvwsys/app/controllers/preferences_controller.rb
+++ b/src/dokumentvwsys/app/controllers/preferences_controller.rb
@@ -3,8 +3,8 @@
 class PreferencesController < ApplicationController
   include AdministrationHelper
 
-  before_action :authenticate_user!
-  before_action :verify_admin_user
+  before_action :authenticate_user!, only: %i[index update]
+  before_action :verify_admin_user, only: %i[index update]
 
   def index
     @preferences = Preference.all.group_by(&:group)

--- a/src/dokumentvwsys/app/views/preferences/_form.html.erb
+++ b/src/dokumentvwsys/app/views/preferences/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for preference, html: { class: 'form-inline row' } do |f| %>
+<%= form_for preference, html: { class: 'row' } do |f| %>
   <%= f.text_field :key, value: preference.key, hidden: true %>
 
   <div class="col-5 input-group mb-2">

--- a/src/dokumentvwsys/config/routes.rb
+++ b/src/dokumentvwsys/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
 
-  resources :preferences
   resources :administration, only: %i[index new edit destroy]
 
   resources :preferences do


### PR DESCRIPTION
--- Why is this change necessary?
1. The text in the file browser was centered but should be left aligned
2. The logo could not be displayed because of a duplicate route

--- How does it address the issue?
1. Remove the form-inline class
2. Remove the duplicate route