### PR TITLE
🐛 Fix daterange for new users

### DIFF
--- a/src/dokumentvwsys/app/views/administration/_form.html.erb
+++ b/src/dokumentvwsys/app/views/administration/_form.html.erb
@@ -32,7 +32,7 @@
 
   <div class="mb-3">
     <%= f.label :birth, t('label.birth') %>
-    <%= f.date_select :birth, class: "form-control" %>
+    <%= f.date_select :birth, class: "form-control", start_year: 1930 %>
   </div>
 
   <div class="mb-3">


### PR DESCRIPTION
The years of the birthdate picker were to small.
Resolves #82